### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Fast poisson disk sampling in 2D in Elixir (& Elixir + Rust), also multi-radius 
 ### Origins of the algorithm
 I stumbled on this **elegant visualisation by Jason Davies** (https://www.jasondavies.com/poisson-disc/), based on the paper **"Fast Poisson Disk Sampling in Arbitrary Dimensions" by Robert Bridson, University of British Columbia.**
 
-I was looking for an algorithm to place items on a bounded map with an homogenous repartition with a natural feel.
+I was looking for an algorithm to place items on a bounded map with an homogeneous repartition with a natural feel.
 
 The linked paper on J.Davies's website was really interesting because of its conciseness and clarity. It fits on a single page.
 

--- a/lib/fastfish_ex.ex
+++ b/lib/fastfish_ex.ex
@@ -101,7 +101,7 @@ defmodule FastfishEx do
     [i | rest] = Enum.shuffle(active_list)
 
     # Generate up to k points chosen uniformly from the spherical annulus between radius r and 2r around xi
-    # For each point, check if it is whithin distance r of existing samples (using the grid to only test nearby samples)
+    # For each point, check if it is within distance r of existing samples (using the grid to only test nearby samples)
     case generate_point(grid, i, k_samples, radius, bounds, random_radius_fn, cell_size) do
       # If a point is adequately far from existing samples, emit it as the next sample (place it in the grid)
       # and add it to the active list


### PR DESCRIPTION
Found via `codespe -S deps -L crate`